### PR TITLE
Support arbitrary slice types

### DIFF
--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 	"math"
+	"reflect"
 
 	"bytes"
 
@@ -207,6 +208,16 @@ func (e Encoder) encode(iVal interface{}) error {
 	case structures.Structure:
 		err = e.encodeStructure(val)
 	default:
+		// arbitrary slice types
+		if reflect.TypeOf(iVal).Kind() == reflect.Slice {
+			s := reflect.ValueOf(iVal)
+			newSlice := make([]interface{}, s.Len())
+			for i := 0; i < s.Len(); i++ {
+				newSlice[i] = s.Index(i).Interface()
+			}
+			return e.encodeSlice(newSlice)
+		}
+
 		return errors.New("Unrecognized type when encoding data for Bolt transport: %T %+v", val, val)
 	}
 


### PR DESCRIPTION
Currently, slices are only supported in the form of []interface{}
This change allows any kind of slice type to be used, as long as the
values in the slice are supported.

This is only a fallback in case callers don't use []interface{}, so it doesn't force any performance penalty on the caller.
