### PR TITLE
Driver pool does not recover connections which return errors

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -129,6 +129,8 @@ func (d *boltDriverPool) OpenPool() (Conn, error) {
 		conn := <-d.pool
 		if conn.conn == nil {
 			if err := conn.initialize(); err != nil {
+				// Return the connection back into the pool
+				d.pool <- conn
 				return nil, err
 			}
 			d.connRefs = append(d.connRefs, conn)


### PR DESCRIPTION
This leads to connection being lost and causes the OpenPool() method to block when all connections have been lost. This can be easily caused by when the neo4j server is down.