### PR TITLE
return the connection back into the pool even if the createConn fails…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -590,7 +590,7 @@ func (c *boltConn) consumeAll() ([]interface{}, interface{}, error) {
 }
 
 func (c *boltConn) consumeAllMultiple(mult int) ([][]interface{}, []interface{}, error) {
-	log.Info("Consuming all responses %d times until success/failure", mult)
+	log.Infof("Consuming all responses %d times until success/failure", mult)
 
 	responses := make([][]interface{}, mult)
 	successes := make([]interface{}, mult)

--- a/conn.go
+++ b/conn.go
@@ -271,12 +271,20 @@ func (c *boltConn) initialize() error {
 	} else if c.driver != nil && c.driver.recorder != nil {
 		c.driver.recorder.Conn, err = c.createConn()
 		if err != nil {
+			// Return the connection back into the pool
+			if e := c.Close(); e != nil {
+				log.Errorf("An error occurred closing connection: %s", e)
+			}
 			return err
 		}
 		c.conn = c.driver.recorder
 	} else {
 		c.conn, err = c.createConn()
 		if err != nil {
+			// Return the connection back into the pool
+			if e := c.Close(); e != nil {
+				log.Errorf("An error occurred closing connection: %s", e)
+			}
 			return err
 		}
 	}

--- a/driver.go
+++ b/driver.go
@@ -3,8 +3,8 @@ package golangNeo4jBoltDriver
 import (
 	"database/sql"
 	"database/sql/driver"
-	"sync"
 	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
+	"sync"
 )
 
 var (
@@ -129,8 +129,6 @@ func (d *boltDriverPool) OpenPool() (Conn, error) {
 		conn := <-d.pool
 		if conn.conn == nil {
 			if err := conn.initialize(); err != nil {
-				// Return the connection back into the pool
-				d.pool <- conn
 				return nil, err
 			}
 			d.connRefs = append(d.connRefs, conn)


### PR DESCRIPTION

the code originally returns to conn pool when initialization has failed, but it has failed to consider the fact that during handshake() method and other methods, they all call conn.Close() which reclaims the connection back into the pool, and the extra return after initializing will cause a deadlock. the underlying problem is when c.createConn() fails, it does not reclaim the connection back into the pool which will cause the deadlock. thus this change will prevent deadlock when connect failed or handshake failed etc. 