### PR TITLE
Prevent panic when RowsAffected is 0

### DIFF
--- a/result.go
+++ b/result.go
@@ -39,6 +39,11 @@ func (r boltResult) LastInsertId() (int64, error) {
 // updated.  If this changes in the future, number updated will be added to the output of this
 // interface.
 func (r boltResult) RowsAffected() (int64, error) {
+	// metadata omits stats when rowsAffected == 0, check existence to prevent panic
+	if  _, ok := r.metadata["stats"]; !ok {
+		return 0, nil
+	}
+
 	stats, ok := r.metadata["stats"].(map[string]interface{})
 	if !ok {
 		return -1, errors.New("Unrecognized type for stats metadata: %#v", r.metadata)


### PR DESCRIPTION
The stats field of the metadata map is omitted from the response when the value to be returned by stmt.RowsAffected() is 0. Calling stmt.RowsAffected() on a statement which has had no effect thus induces a panic, because the stats field was assumed to exist.

Checking for the fields existence prior to the type assertion prevents panic wherein the non-existent field was type asserted to map[string]interface{}.