### PR TITLE
Use of nil reference when connection cannot be opened

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -387,12 +387,14 @@ func (c *boltConn) Close() error {
 		return nil
 	}
 
-	err := c.conn.Close()
-	c.closed = true
-	if err != nil {
-		c.connErr = errors.Wrap(err, "An error occurred closing the connection")
-		return driver.ErrBadConn
+	if c.conn != nil {
+		err := c.conn.Close()
+		if err != nil {
+			c.connErr = errors.Wrap(err, "An error occurred closing the connection")
+			return driver.ErrBadConn
+		}
 	}
+	c.closed = true
 
 	return nil
 }


### PR DESCRIPTION
I had this error when the Dial connection was not able to connect to the DB.
After investigations, you used the nil `c.conn` object is the Close method.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x612a5b]
```